### PR TITLE
Allow zero files to be provided via -L option

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if len(files) == 0 {
+	if len(files) == 0 && len(inputFile) == 0 {
 		fmt.Fprintf(os.Stderr, "no file specified\n\n")
 		flag.Usage()
 		os.Exit(1)


### PR DESCRIPTION
This is particularly useful when using `gotags` to create tag files for git repositories that may or may not contain go files:

``` bash
git ls-files '*.go' '**/*.go' | gotags -L -
```
