### PR TITLE
Vim easytags compatibility

### DIFF
--- a/fields.go
+++ b/fields.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// FieldSet is a set of extension fields to include in a tag.
+type FieldSet map[TagField]bool
+
+// Includes tests whether the given field is included in the set.
+func (f FieldSet) Includes(field TagField) bool {
+	b, ok := f[field]
+	return ok && b
+}
+
+// ErrInvalidFields is an error returned when attempting to parse invalid
+// fields.
+type ErrInvalidFields struct {
+	Fields string
+}
+
+func (e ErrInvalidFields) Error() string {
+	return fmt.Sprintf("invalid fields: %s", e.Fields)
+}
+
+// currently only "+l" is supported
+var fieldsPattern = regexp.MustCompile(`^\+l$`)
+
+func parseFields(fields string) (FieldSet, error) {
+	if fields == "" {
+		return FieldSet{}, nil
+	}
+	if fieldsPattern.MatchString(fields) {
+		return FieldSet{Language: true}, nil
+	}
+	return FieldSet{}, ErrInvalidFields{fields}
+}

--- a/fields_test.go
+++ b/fields_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestParseFieldsEmpty(t *testing.T) {
+	_, err := parseFields("")
+	if err != nil {
+		t.Fatalf("unexpected error from parseFields: %s", err)
+	}
+}
+
+func TestParseFieldsLanguage(t *testing.T) {
+	set, err := parseFields("+l")
+	if err != nil {
+		t.Fatalf("unexpected error from parseFields: %s", err)
+	}
+	if !set.Includes(Language) {
+		t.Fatal("expected set to include Language")
+	}
+}
+
+func TestParseFieldsInvalid(t *testing.T) {
+	_, err := parseFields("junk")
+	if err == nil {
+		t.Fatal("expected parseFields to return error")
+	}
+	if _, ok := err.(ErrInvalidFields); !ok {
+		t.Fatalf("expected parseFields to return error of type ErrInvalidFields, got %T", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ var (
 	silent       bool
 	relative     bool
 	listLangs    bool
+	fields       string
 )
 
 // Initialize flags.
@@ -42,6 +43,7 @@ func init() {
 	flag.BoolVar(&silent, "silent", false, "do not produce any output on error.")
 	flag.BoolVar(&relative, "tag-relative", false, "file paths should be relative to the directory containing the tag file.")
 	flag.BoolVar(&listLangs, "list-languages", false, "list supported languages.")
+	flag.StringVar(&fields, "fields", "", "include selected extension fields (only +l).")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "gotags version %s\n\n", Version)
@@ -164,6 +166,13 @@ func main() {
 		}
 	}
 
+	fieldSet, err := parseFields(fields)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n\n", err)
+		flag.Usage()
+		os.Exit(1)
+	}
+
 	tags := []Tag{}
 	for _, file := range files {
 		ts, err := Parse(file, relative, basedir)
@@ -178,6 +187,9 @@ func main() {
 
 	output := createMetaTags()
 	for _, tag := range tags {
+		if fieldSet.Includes(Language) {
+			tag.Fields[Language] = "Go"
+		}
 		output = append(output, tag.String())
 	}
 

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ var (
 	sortOutput   bool
 	silent       bool
 	relative     bool
+	listLangs    bool
 )
 
 // Initialize flags.
@@ -40,6 +41,7 @@ func init() {
 	flag.BoolVar(&sortOutput, "sort", true, "sort tags.")
 	flag.BoolVar(&silent, "silent", false, "do not produce any output on error.")
 	flag.BoolVar(&relative, "tag-relative", false, "file paths should be relative to the directory containing the tag file.")
+	flag.BoolVar(&listLangs, "list-languages", false, "list supported languages.")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "gotags version %s\n\n", Version)
@@ -130,6 +132,11 @@ func main() {
 
 	if printVersion {
 		fmt.Printf("gotags version %s\n", Version)
+		return
+	}
+
+	if listLangs {
+		fmt.Println("Go")
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -33,22 +33,25 @@ var (
 	fields       string
 )
 
+// ignore unknown flags
+var flags = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+
 // Initialize flags.
 func init() {
-	flag.BoolVar(&printVersion, "v", false, "print version.")
-	flag.StringVar(&inputFile, "L", "", `source file names are read from the specified file. If file is "-", input is read from standard in.`)
-	flag.StringVar(&outputFile, "f", "", `write output to specified file. If file is "-", output is written to standard out.`)
-	flag.BoolVar(&recurse, "R", false, "recurse into directories in the file list.")
-	flag.BoolVar(&sortOutput, "sort", true, "sort tags.")
-	flag.BoolVar(&silent, "silent", false, "do not produce any output on error.")
-	flag.BoolVar(&relative, "tag-relative", false, "file paths should be relative to the directory containing the tag file.")
-	flag.BoolVar(&listLangs, "list-languages", false, "list supported languages.")
-	flag.StringVar(&fields, "fields", "", "include selected extension fields (only +l).")
+	flags.BoolVar(&printVersion, "v", false, "print version.")
+	flags.StringVar(&inputFile, "L", "", `source file names are read from the specified file. If file is "-", input is read from standard in.`)
+	flags.StringVar(&outputFile, "f", "", `write output to specified file. If file is "-", output is written to standard out.`)
+	flags.BoolVar(&recurse, "R", false, "recurse into directories in the file list.")
+	flags.BoolVar(&sortOutput, "sort", true, "sort tags.")
+	flags.BoolVar(&silent, "silent", false, "do not produce any output on error.")
+	flags.BoolVar(&relative, "tag-relative", false, "file paths should be relative to the directory containing the tag file.")
+	flags.BoolVar(&listLangs, "list-languages", false, "list supported languages.")
+	flags.StringVar(&fields, "fields", "", "include selected extension fields (only +l).")
 
-	flag.Usage = func() {
+	flags.Usage = func() {
 		fmt.Fprintf(os.Stderr, "gotags version %s\n\n", Version)
 		fmt.Fprintf(os.Stderr, "Usage: %s [options] file(s)\n\n", os.Args[0])
-		flag.PrintDefaults()
+		flags.PrintDefaults()
 	}
 }
 
@@ -113,7 +116,7 @@ func readNames(names []string) ([]string, error) {
 func getFileNames() ([]string, error) {
 	var names []string
 
-	names = append(names, flag.Args()...)
+	names = append(names, flags.Args()...)
 	names, err := readNames(names)
 	if err != nil {
 		return nil, err
@@ -130,7 +133,7 @@ func getFileNames() ([]string, error) {
 }
 
 func main() {
-	flag.Parse()
+	flags.Parse(os.Args[1:])
 
 	if printVersion {
 		fmt.Printf("gotags version %s\n", Version)
@@ -145,13 +148,13 @@ func main() {
 	files, err := getFileNames()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "cannot get specified files\n\n")
-		flag.Usage()
+		flags.Usage()
 		os.Exit(1)
 	}
 
 	if len(files) == 0 && len(inputFile) == 0 {
 		fmt.Fprintf(os.Stderr, "no file specified\n\n")
-		flag.Usage()
+		flags.Usage()
 		os.Exit(1)
 	}
 
@@ -169,7 +172,7 @@ func main() {
 	fieldSet, err := parseFields(fields)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n\n", err)
-		flag.Usage()
+		flags.Usage()
 		os.Exit(1)
 	}
 

--- a/tag.go
+++ b/tag.go
@@ -28,6 +28,7 @@ const (
 	ReceiverType  TagField = "ctype"
 	Line          TagField = "line"
 	InterfaceType TagField = "ntype"
+	Language      TagField = "language"
 )
 
 // TagType represents the type of a tag in a tag line.


### PR DESCRIPTION
Summary of changes:

* Respond to the `--list-languages` flag
* Add `language:Go` field if `--fields=+l` is set
* Ignore unknown flags (e.g. `--c-kinds`)

I'm not sure about the last one, but I needed it to get things to work, and I preferred it to adding unused flags.