### PR TITLE
Print detailed error message

### DIFF
--- a/main.go
+++ b/main.go
@@ -149,7 +149,7 @@ func main() {
 
 	files, err := getFileNames()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "cannot get specified files\n\n")
+		fmt.Fprintf(os.Stderr, "cannot get specified files: %v\n\n", err)
 		flags.Usage()
 		os.Exit(1)
 	}


### PR DESCRIPTION
Error message "cannot get specified files" isn't enough for user to investigate why gotags doesn't work, we should print detailed error message for user.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>