### PR TITLE
Add support for variadic functions

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -360,6 +360,8 @@ func getType(node ast.Node, star bool) (paramType string) {
 		paramType = fmt.Sprintf("chan %s", getType(t.Value, true))
 	case *ast.InterfaceType:
 		paramType = "interface{}"
+	case *ast.Ellipsis:
+		paramType = fmt.Sprintf("...%s", getType(t.Elt, true))
 	}
 	return
 }


### PR DESCRIPTION
Fixes #33 

**Before** patch
```
Printf        /usr/local/go/src/fmt/print.go  189;"   f       access:public   line:189        signature:(format string, a )   type:int, error
```

**After** patch
```
Printf        /usr/local/go/src/fmt/print.go  189;"   f       access:public   line:189        signature:(format string, a ...interface{})     type:int, error
```