### PR TITLE
Remove tagbar config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,36 +29,7 @@ Or using package manager `brew` on OS X
 	-v=false: print version.
 
 ## Vim [Tagbar][] configuration
-
-Put the following configuration in your vimrc:
-
-	let g:tagbar_type_go = {
-		\ 'ctagstype' : 'go',
-		\ 'kinds'     : [
-			\ 'p:package',
-			\ 'i:imports:1',
-			\ 'c:constants',
-			\ 'v:variables',
-			\ 't:types',
-			\ 'n:interfaces',
-			\ 'w:fields',
-			\ 'e:embedded',
-			\ 'm:methods',
-			\ 'r:constructor',
-			\ 'f:functions'
-		\ ],
-		\ 'sro' : '.',
-		\ 'kind2scope' : {
-			\ 't' : 'ctype',
-			\ 'n' : 'ntype'
-		\ },
-		\ 'scope2kind' : {
-			\ 'ctype' : 't',
-			\ 'ntype' : 'n'
-		\ },
-		\ 'ctagsbin'  : 'gotags',
-		\ 'ctagsargs' : '-sort -silent'
-	\ }
+The latest version of tagbar integrates perfectly with gotags. No configuration needed.
 
 ### Vim+Tagbar Screenshot
 ![vim Tagbar gotags](https://stemmertech.com/images/gotags-1.0.0-screenshot.png)


### PR DESCRIPTION
Tagbar added default go configs if gotags is detected. There's now no need for these additional configs.
https://github.com/majutsushi/tagbar/pull/580