### PR TITLE
add module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/jstemmer/gotags
+
+go 1.16


### PR DESCRIPTION
It is not possible to build binaries without a module in recent versions
of the toolchain.